### PR TITLE
Always log dmesg if zfs-tests times out

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -542,7 +542,7 @@ test_factory.addStep(ShellCommand(
     haltOnFailure=False, flunkOnWarnings=True,
     maxTime=36000, sigtermTime=30, logEnviron=False,
     lazylogfiles=True, timeout=4200,
-    logfiles={"console"  : { "filename" : "console.log",  "follow" : False },
+    logfiles={"console"  : { "filename" : "console.log",  "follow" : True },
               "summary"  : { "filename" : "summary.log",  "follow" : False },
               "tests"    : { "filename" : "test.log",     "follow" : True },
               "log"      : { "filename" : "full.log",     "follow" : True },


### PR DESCRIPTION
This patch allows the zfs-test suite to ensure that console.log
is always recorded even if the process needs to be killed.

Signed-off-by: Tom Caputi <tcaputi@datto.com>