### PR TITLE
Disable loadable kernel module support

### DIFF
--- a/scripts/bb-build-linux.sh
+++ b/scripts/bb-build-linux.sh
@@ -19,6 +19,7 @@ CONFIG_CRYPTO_DEFLATE=y
 CONFIG_ZLIB_DEFLATE=y
 CONFIG_KALLSYMS=y
 CONFIG_EFI_PARTITION=y
+CONFIG_MODULES=n
 EOF
 
 # Expect a spl and zfs directory to apply source from.


### PR DESCRIPTION
By default disable loadable kernel module support when testing
the builtin support via the CI.

Issue: openzfs/zfs#9887
Issue: openzfs/zfs#10063
