### PR TITLE
Revert "Disable loadable kernel module support"

### DIFF
--- a/scripts/bb-build-linux.sh
+++ b/scripts/bb-build-linux.sh
@@ -19,7 +19,6 @@ CONFIG_CRYPTO_DEFLATE=y
 CONFIG_ZLIB_DEFLATE=y
 CONFIG_KALLSYMS=y
 CONFIG_EFI_PARTITION=y
-CONFIG_MODULES=n
 EOF
 
 # Expect a spl and zfs directory to apply source from.


### PR DESCRIPTION
Reverts openzfs/zfs-buildbot#183.  Additional changes are required to
the build script to support this.  It is being reverted for now.