### PR TITLE
Increase max_threads_per_proc for ztest on FreeBSD

### DIFF
--- a/scripts/bb-test-pts.sh
+++ b/scripts/bb-test-pts.sh
@@ -134,9 +134,21 @@ $PTS user-config-set PromptForTestDescription="FALSE" >>$CONFIG_LOG 2>&1
 $PTS user-config-set PromptSaveName="FALSE" >>$CONFIG_LOG 2>&1
 $PTS user-config-set Configured="TRUE" >>$CONFIG_LOG 2>&1
 
-if ! test -e /sys/module/zfs; then
+case $(uname) in
+FreeBSD)
+	if ! kldstat -qn openzfs; then
+		sudo -E $ZFS_SH
+	fi
+	;;
+Linux)
+	if ! test -e /sys/module/zfs; then
+		sudo -E $ZFS_SH
+	fi
+	;;
+*)
 	sudo -E $ZFS_SH
-fi
+	;;
+esac
 
 # If not given, read the zfs version and trim the hash to 7 characters.
 # This ensures that once merged all the test results will be in the same

--- a/scripts/bb-test-zfstests.sh
+++ b/scripts/bb-test-zfstests.sh
@@ -92,9 +92,21 @@ PERF_FS_OPTS=${TEST_ZFSTESTS_PERF_FS_OPTS:-"$DEFAULT_ZFSTESTS_PERF_FS_OPTS"}
 
 set +x
 
-if ! test -e /sys/module/zfs; then
-    sudo -E $ZFS_SH
-fi
+case $(uname) in
+FreeBSD)
+	if ! kldstat -qn openzfs; then
+		sudo -E $ZFS_SH
+	fi
+	;;
+Linux)
+	if ! test -e /sys/module/zfs; then
+	    sudo -E $ZFS_SH
+	fi
+	;;
+*)
+	sudo -E $ZFS_SH
+	;;
+esac
 
 # Performance profiling disabled by default due to size of profiling data.
 if echo "$TEST_ZFSTESTS_PROFILE" | grep -Eiq "^yes$|^on$|^true$|^1$"; then

--- a/scripts/bb-test-ztest.sh
+++ b/scripts/bb-test-ztest.sh
@@ -62,9 +62,22 @@ TEST_ZTEST_KEEP_CORE_DIR="Yes"
 
 set +x
 
-if ! test -e /sys/module/zfs; then
-    sudo -E $ZFS_SH
-fi
+case $(uname) in
+FreeBSD)
+	if ! kldstat -qn openzfs; then
+		sudo -E $ZFS_SH
+	fi
+	sudo -E sysctl kern.threads.max_threads_per_proc=5000 >/dev/null
+	;;
+Linux)
+	if ! test -e /sys/module/zfs; then
+	    sudo -E $ZFS_SH
+	fi
+	;;
+*)
+	sudo -E $ZFS_SH
+	;;
+esac
 
 sudo -E mkdir -p "$TEST_ZTEST_DIR"
 sudo -E $ZLOOP_SH $TEST_ZTEST_OPTIONS \


### PR DESCRIPTION
And use the correct test to check if the openzfs module is loaded.

Signed-off-by: Ryan Moeller <ryan@iXsystems.com>