### PR TITLE
Enable use of alternative NVMe driver for FreeBSD

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -351,11 +351,18 @@ FreeBSD*)
     echo "fdescfs /dev/fd fdescfs rw 0 0" >> /etc/fstab
     mount /dev/fd
 
-    if [ -c /dev/nvd1 ]; then
-        gpart create -s gpt nvd1
-        gpart add -t freebsd-ufs nvd1
-        newfs nvd1p1
-        echo "/dev/nvd1p1 /mnt ufs rw,noatime" >> /etc/fstab
+    if [ -c /dev/nda1 ]; then
+        nvme=nda1
+    elif [ -c /dev/nvd1 ]; then
+        nvme=nvd1
+    else
+        nvme=""
+    fi
+    if [ -n "$nvme" ]; then
+        gpart create -s gpt ${nvme}
+        gpart add -t freebsd-ufs ${nvme}
+        newfs ${nvme}p1
+        echo "/dev/${nvme}p1 /mnt ufs rw,noatime" >> /etc/fstab
         mount /mnt
     fi
     ;;


### PR DESCRIPTION
The FreeBSD HEAD snapshot AMIs are being switched to the newer nda
driver for NVMe devices.  Snapshots for FreeBSD stable/12 remain on
nvd.

Update the bootstrap script to detect which of the two is in use.

Signed-off-by: Ryan Moeller <ryan@iXsystems.com>