### PR TITLE
Ensure ZFS exports file is used by FreeBSD NFS server

### DIFF
--- a/scripts/bb-test-prepare.sh
+++ b/scripts/bb-test-prepare.sh
@@ -214,6 +214,7 @@ if echo "$TEST_PREPARE_SHARES" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
 
     FreeBSD*)
         sudo -E touch /etc/exports
+        sudo -E sysrc mountd_flags="/etc/zfs/exports"
         sudo -E service nfsd onestart
         echo '[global]' | sudo -E tee /usr/local/etc/smb4.conf >/dev/null
         sudo -E service samba_server onestart


### PR DESCRIPTION
This will be needed when eventually we get the zfs_share tests working on FreeBSD.

Normally the mountd rc script check zfs_enable and adds the ZFS exports file automatically, but we don't want to set that for the test bots because it enables many "conveniences" we aren't interested in.