### PR TITLE
Wait longer for pkg lock via global config

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -351,6 +351,17 @@ Fedora*)
     ;;
 
 FreeBSD*)
+    cat >>/usr/local/etc/pkg.conf <<EOF
+
+# OpenZFS buildbot bootstrap needs pkg to succeed when we ask it to install
+# packages.  If that means waiting for other pkg installs to complete, fine.
+# We wait 60 seconds per try, and retry up to 5 times.
+LOCK_RETRIES = 5;
+LOCK_WAIT = 60;
+
+DEBUG_LEVEL = 1;
+EOF
+
     pkg install -y \
         curl \
         git-lite \

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -140,12 +140,6 @@ Fedora*)
     ;;
 
 FreeBSD*)
-    pkg_pid=$(pgrep pkg 2>/dev/null)
-    if [ -n "${pkg_pid}" ]; then
-        echo "Waiting for other pkg install to finish..."
-        pwait ${pkg_pid}
-    fi
-
     # Always test with the latest packages on FreeBSD.
     sudo -E pkg upgrade -y --no-repo-update
 


### PR DESCRIPTION
Should fix the latest crop of FreeBSD failures.