### PR TITLE
Temporary workaround for FreeBSD pkg db locking race

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -116,6 +116,15 @@ standardize_storage () {
     fi
 }
 
+# Temporary workaround for FreeBSD pkg db locking race
+pkg_install () {
+    local pkg_pid=$(pgrep pkg 2>/dev/null)
+    if [ -n  "${pkg_pid}" ]; then
+        pwait ${pkg_pid}
+    fi
+    pkg install "${@}"
+}
+
 set -x
 
 case "$BB_NAME" in
@@ -362,7 +371,7 @@ LOCK_WAIT = 60;
 DEBUG_LEVEL = 1;
 EOF
 
-    pkg install -y \
+    pkg_install -y \
         curl \
         git-lite \
         py27-pip \


### PR DESCRIPTION
Check if pkg is already running and wait if so before each pkg command.
This still leaves a small race window which is why this ultimately
needs to be fixed in pkg, but it should help in the meantime.