### PR TITLE
Update FreeBSD stable/12 version

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -748,7 +748,7 @@ def freebsd_ami(abi, version):
     return data['ImageId']
 
 def get_freebsd12_image(slave):
-    slave.ami = freebsd_ami("amd64", "12.1-STABLE")
+    slave.ami = freebsd_ami("amd64", "12.2-PRERELEASE")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):


### PR DESCRIPTION
FreeBSD has entered the prerelease cycle for 12.2 on the stable/12 branch. The image location must be updated accordingly.