### PR TITLE
add debian10 arm64 slaves

### DIFF
--- a/master/buildslaves.py
+++ b/master/buildslaves.py
@@ -217,9 +217,14 @@ class ZFSEC2StyleSlave(ZFSEC2Slave):
 
 # Create an HVM EC2 large latent build slave
 class ZFSEC2BuildSlave(ZFSEC2Slave):
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, arch="amd64", **kwargs):
+        instance_types = {
+            "amd64": "c5d.large",
+            "arm64": "a1.xlarge"
+        }
+        assert arch in instance_types
         ZFSEC2Slave.__init__(self, name, mode="BUILD",
-            instance_type="c5d.large", max_spot_price=0.10, placement='b',
+            instance_type=instance_types.get(arch), max_spot_price=0.10, placement='b',
             spot_instance=True, **kwargs)
 
 # Create an HVM EC2 latent test slave

--- a/master/buildslaves.py
+++ b/master/buildslaves.py
@@ -220,7 +220,7 @@ class ZFSEC2BuildSlave(ZFSEC2Slave):
     def __init__(self, name, arch="amd64", **kwargs):
         instance_types = {
             "amd64": "c5d.large",
-            "arm64": "a1.xlarge"
+            "arm64": "c6g.large"
         }
         assert arch in instance_types
         ZFSEC2Slave.__init__(self, name, mode="BUILD",

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -727,7 +727,8 @@ centos7_ami = "ami-4826c22b"		# CentOS 7 5-17-2018
 centos8_ami = "ami-04179d30492b778ad"	# CentOS 8 6-18-2020
 
 # Provided by Debian: https://wiki.debian.org/Cloud/AmazonEC2Image
-debian10_ami = "ami-0ed1af421f2a3cf40"	# Debian 10 9-9-2019
+debian10_amd64_ami = "ami-0ed1af421f2a3cf40" # Debian 10 9-9-2019
+debian10_arm64_ami = "ami-0a61b13f06119b46c" # Debian 10 9-28-2020
 
 # Provided by Fedora: https://alt.fedoraproject.org/cloud/
 fedora32_ami = "ami-0ff5d4e010e1524ee"	# Fedora 32 6-9-2020
@@ -779,6 +780,14 @@ debian8_arm_slave = [
         slave_userpass["Debian-8-arm-buildslave1"]),
     BuildSlave("Debian-8-arm-buildslave2",
         slave_userpass["Debian-8-arm-buildslave2"]),
+]
+
+debian10_arm64_slave = [
+    ZFSEC2BuildSlave(
+        name="Debian-10-arm64-buildslave%s" % (str(i+1)),
+        ami=debian10_arm64_ami,
+        arch="arm64"
+    ) for i in range(0, numarchslaves)
 ]
 
 ubuntu16_aarch64_slave = [
@@ -844,7 +853,7 @@ centos8_x86_64_testslave = [
 debian10_x86_64_testslave = [
     ZFSEC2TestSlave(
         name="Debian-10-x86_64-testslave%s" % (str(i+1)),
-        ami=debian10_ami
+        ami=debian10_amd64_ami
     ) for i in range(0, numtestslaves)
 ]
 
@@ -1184,6 +1193,13 @@ arch_builders = [
         name="Debian 8 arm (BUILD)",
         factory=build_factory,
         slavenames=[slave.slavename for slave in debian8_arm_slave],
+        tags=arch_tags,
+        properties=builder_arch_properties,
+    ),
+    ZFSBuilderConfig(
+        name="Debian 10 arm64 (BUILD)",
+        factory=build_factory,
+        slavenames=[slave.slavename for slave in debian10_arm64_slave],
         tags=arch_tags,
         properties=builder_arch_properties,
     ),

--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -104,7 +104,7 @@ standardize_storage () {
     inst_dev="$1"
     nvme_dev="$(ls -1 /dev/disk/by-id/*NVMe_Instance_Storage* | head -1)"
 
-    if test -b $nvme_dev; then
+    if test -b "$nvme_dev"; then
         echo "$nvme_dev /mnt ext4 defaults,noatime" >>/etc/fstab
         mkfs.ext4 $nvme_dev
     elif test -b $inst_dev; then

--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -469,7 +469,7 @@ fi
 
 # Generic buildslave configuration
 if test ! -d $BB_DIR; then
-    mkdir -p $BB_DIR
+    mkdir -p $BB_DIR/info
     chown buildbot:buildbot $BB_DIR
     sudo -E -u buildbot $BUILDSLAVE create-slave --umask=022 --usepty=0 $BB_PARAMS
 fi

--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -263,9 +263,16 @@ Debian*)
         apt-get --yes install curl buildbot-slave
     fi
 
+    ARCH=$(dpkg --print-architecture)
     # Install the latest kernel to reboot on to.
     if test "$BB_MODE" = "TEST" -o "$BB_MODE" = "PERF"; then
-        apt-get --yes install --only-upgrade linux-image-amd64
+        apt-get --yes install --only-upgrade linux-image-$ARCH
+        REBOOT=1
+    fi
+    # Buster has a different arm64 kernel (5.7 vs 4.19) for EC2
+    # From Bullseye up linux-image and limux-image-cloud are the same release
+    if test $VERSION -eq 10 -a "$ARCH" = "arm64"; then
+        apt-get --yes install linux-image-cloud-arm64
         REBOOT=1
     fi
 


### PR DESCRIPTION
I've noticed that there has been a small handful of issues with GPL
violations on arm64 over the past year or so. It seems like this is
something we can catch by leveraging the AWS graviton arm64 instances
for build slaves.