### PR TITLE
FreeBSD fixes

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -412,8 +412,7 @@ EOF
         gpart create -s gpt ${nvme}
         gpart add -t freebsd-ufs ${nvme}
         newfs ${nvme}p1
-        echo "/dev/${nvme}p1 /mnt ufs rw,noatime" >> /etc/fstab
-        mount /mnt
+        mount -o noatime /dev/${nvme}p1 /mnt
     fi
     ;;
 

--- a/scripts/bb-build.sh
+++ b/scripts/bb-build.sh
@@ -7,6 +7,9 @@ fi
 case "$BB_NAME" in
 FreeBSD*)
 	MAKE=gmake
+	if [ $(freebsd-version -k) = "13.0-CURRENT" ]; then
+		MAKE="$MAKE WITH_DEBUG=true"
+	fi
 	NCPU=$(sysctl -n hw.ncpu)
 	;;
 Amazon*|CentOS*|Debian*|Fedora*|SUSE*|Ubuntu*)


### PR DESCRIPTION
We need to build ZFS with WITH_DEBUG=true on FreeBSD for INVARIANTS because apparently the kernel modules are supposed to match the kernel state of this option.