### PR TITLE
FreeBSD: Build with WITH_INVARIANTS=true on head

### DIFF
--- a/scripts/bb-build.sh
+++ b/scripts/bb-build.sh
@@ -8,7 +8,7 @@ case "$BB_NAME" in
 FreeBSD*)
 	MAKE=gmake
 	if [ $(freebsd-version -k) = "13.0-CURRENT" ]; then
-		MAKE="$MAKE WITH_DEBUG=true"
+		MAKE="$MAKE WITH_DEBUG=true WITH_INVARIANTS=true"
 	fi
 	NCPU=$(sysctl -n hw.ncpu)
 	;;


### PR DESCRIPTION
Combined with https://github.com/openzfs/zfs/pull/11213, this ensures we build the module with INVARIANTS to match the kernel on head.