### PR TITLE
 FreeBSD: Build with WITH_DEBUG=true on 12, too 

### DIFF
--- a/scripts/bb-build.sh
+++ b/scripts/bb-build.sh
@@ -6,9 +6,9 @@ fi
 
 case "$BB_NAME" in
 FreeBSD*)
-	MAKE=gmake
+	MAKE="gmake WITH_DEBUG=true"
 	if [ $(freebsd-version -k) = "13.0-CURRENT" ]; then
-		MAKE="$MAKE WITH_DEBUG=true WITH_INVARIANTS=true"
+		MAKE="$MAKE WITH_INVARIANTS=true"
 	fi
 	NCPU=$(sysctl -n hw.ncpu)
 	;;


### PR DESCRIPTION
After openzfs/zfs#11213 is merged we will be able to build with WITH_DEBUG=true on stable/12.

We can wait a bit after merging that commit before merging this. Give some time for PRs to be rebased so we don't break the working stable/12 bot.