### PR TITLE
FreeBSD: Split up test dependencies

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -176,13 +176,22 @@ FreeBSD*)
         gmake \
         libtool
 
-    # Testing support utilities
+    # Essential testing utilities
+    # No tests will run if these are missing.
     pkg_install -y --no-repo-update \
-        base64 \
-        fio \
         ksh93 \
         python \
-        python3 \
+        python3
+
+    # Important testing utilities
+    # Many tests will fail if these are missing.
+    pkg_install -y --no-repo-update \
+        base64 \
+        fio
+
+    # Testing support utilities
+    # Only a few tests require these.
+    pkg_install -y --no-repo-update \
         samba413 \
         gdb \
         pamtester \


### PR DESCRIPTION
Occasionally packages are broken in the FreeBSD head repo.  When one
package fails to install, the rest of the packages in the same command
invocation fail as well.

Split up the test dependencies into groups by necessity, so that when
a non-essential utility such as gdb fails to install, we still install
essential packages like ksh93 and python.  This allows most tests to
run as long as we aren't missing something essential.

Signed-off-by: Ryan Moeller <ryan@iXsystems.com>