### PR TITLE
FreeBSD: Use ensurepip to get pip-2.7

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -398,9 +398,10 @@ EOF
     pkg_install -y \
         curl \
         git-lite \
-        py27-pip \
+        python27 \
         sudo
-    pip-2.7 --quiet install buildbot-slave
+    python2.7 -m ensurepip
+    pip --quiet install buildbot-slave
 
     pw useradd buildbot
     echo "buildbot ALL=(ALL) NOPASSWD: ALL" \


### PR DESCRIPTION
py27-pip has been dropped from the pkg repo.