### PR TITLE
FreeBSD: Update for 13.0-ALPHA1 branch rename

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -491,7 +491,7 @@ def get_freebsd12_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.0-CURRENT")
+    slave.ami = freebsd_ami("amd64", "13.0-ALPHA1")
     return slave.conn.get_image(slave.ami)
 
 #


### PR DESCRIPTION
https://freebsdamiregistrystack-freebsdamiregistry0b72b4d-170sx91rgh82n.s3.amazonaws.com/amd64/13.0-ALPHA1/latest.json