### PR TITLE
FreeBSD: Relax version check for WITH_INVARIANTS

### DIFF
--- a/scripts/bb-build.sh
+++ b/scripts/bb-build.sh
@@ -7,7 +7,7 @@ fi
 case "$BB_NAME" in
 FreeBSD*)
 	MAKE="gmake WITH_DEBUG=true"
-	if [ $(freebsd-version -k) = "13.0-CURRENT" ]; then
+	if expr $(freebsd-version -k) : "13.0-" >/dev/null; then
 		MAKE="$MAKE WITH_INVARIANTS=true"
 	fi
 	NCPU=$(sysctl -n hw.ncpu)


### PR DESCRIPTION
When building for FreeBSD HEAD we need to use WITH_INVARIANTS=true to
match the kernel configuration.  The release cycle for FreeBSD 13 has
begun so the kernel version is changing from 13.0-CURRENT to -ALPHA*
and later -BETA* and -RC*.

Relax the version check to only look for 13.0- rather than the full
string, so we don't have to babysit this quite so much during the
release cycle.