### PR TITLE
FreeBSD: Update for stable/13 and 14 main branches

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -491,7 +491,7 @@ def get_freebsd12_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.0-RC1")
+    slave.ami = freebsd_ami("amd64", "13.0-RC2")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd14_image(slave):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -494,6 +494,10 @@ def get_freebsd13_image(slave):
     slave.ami = freebsd_ami("amd64", "13.0-RC1")
     return slave.conn.get_image(slave.ami)
 
+def get_freebsd14_image(slave):
+    slave.ami = freebsd_ami("amd64", "14.0-CURRENT")
+    return slave.conn.get_image(slave.ami)
+
 #
 # Architecture slaves
 #
@@ -604,8 +608,15 @@ freebsd12_amd64_testslave = [
 
 freebsd13_amd64_testslave = [
     ZFSEC2TestSlave(
-        name="FreeBSD-head-amd64-testslave%s" % (str(i+1)),
+        name="FreeBSD-stable/13-amd64-testslave%s" % (str(i+1)),
         get_image=get_freebsd13_image
+    ) for i in range(0, numtestslaves)
+]
+
+freebsd14_amd64_testslave = [
+    ZFSEC2TestSlave(
+        name="FreeBSD-main-amd64-testslave%s" % (str(i+1)),
+        get_image=get_freebsd14_image
     ) for i in range(0, numtestslaves)
 ]
 
@@ -619,7 +630,8 @@ test_slaves = \
     ubuntu18_x86_64_testslave + \
     ubuntu20_x86_64_testslave + \
     freebsd12_amd64_testslave + \
-    freebsd13_amd64_testslave
+    freebsd13_amd64_testslave + \
+    freebsd14_amd64_testslave
 
 #
 # Other (Built-in, Style, Coverage, Performance)
@@ -953,9 +965,19 @@ freebsd_12_builders = [
 
 freebsd_13_builders = [
     ZFSBuilderConfig(
-        name="FreeBSD head amd64 (TEST)",
+        name="FreeBSD stable/13 amd64 (TEST)",
         factory=test_factory,
         slavenames=[slave.name for slave in freebsd13_amd64_testslave],
+        tags=platform_tags,
+        properties=builder_freebsd_properties,
+    ),
+]
+
+freebsd_14_builders = [
+    ZFSBuilderConfig(
+        name="FreeBSD main amd64 (TEST)",
+        factory=test_factory,
+        slavenames=[slave.name for slave in freebsd14_amd64_testslave],
         tags=platform_tags,
         properties=builder_freebsd_properties,
     ),
@@ -971,7 +993,8 @@ test_builders = \
     ubuntu_18_builders + \
     ubuntu_20_builders + \
     freebsd_12_builders + \
-    freebsd_13_builders
+    freebsd_13_builders + \
+    freebsd_14_builders
 
 
 #
@@ -1163,6 +1186,12 @@ c['schedulers'].append(CustomSingleBranchScheduler(
     builderNames=[builder.name for builder in freebsd_13_builders],
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*freebsd13.*")))
+
+c['schedulers'].append(CustomSingleBranchScheduler(
+    name="pull-request-freebsd-14-scheduler",
+    builderNames=[builder.name for builder in freebsd_14_builders],
+    codebases=default_codebases,
+    change_filter=filter.ChangeFilter(category_re=".*freebsd14.*")))
 
 # Other (built-in, coverage, performance)
 c['schedulers'].append(CustomSingleBranchScheduler(


### PR DESCRIPTION
FreeBSD stable/13 has been branched and the debug options turned off.
SVN "HEAD" is now the git "main" branch for FreeBSD 14.0-CURRENT.

Add builders for 14 and make WITH_INVARIANTS=true apply to 14 only.