### PR TITLE
FreeBSD: Use 13.0-BETA4 release images for now

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -491,7 +491,7 @@ def get_freebsd12_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.0-ALPHA2")
+    slave.ami = freebsd_ami("amd64", "13.0-BETA4")
     return slave.conn.get_image(slave.ami)
 
 #

--- a/scripts/bb-build.sh
+++ b/scripts/bb-build.sh
@@ -7,7 +7,7 @@ fi
 case "$BB_NAME" in
 FreeBSD*)
 	MAKE="gmake WITH_DEBUG=true"
-	if expr $(freebsd-version -k) : "14.0-" >/dev/null; then
+	if sysctl -n kern.conftxt | fgrep -qx $'options\tINVARIANTS'; then
 		MAKE="$MAKE WITH_INVARIANTS=true"
 	fi
 	NCPU=$(sysctl -n hw.ncpu)

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -162,7 +162,10 @@ FreeBSD*)
         ABI=$(uname -p)
         VERSION=$(freebsd-version -r)
         cd /tmp
+        # One of these will work, the other will fail.  We try both because 13 is
+        # in RC so there are not stable/13 snapshots at the moment.
         fetch https://download.freebsd.org/ftp/snapshots/${ABI}/${VERSION}/src.txz
+        fetch https://download.freebsd.org/ftp/releases/${ABI}/${VERSION}/src.txz
         sudo tar xpf src.txz -C /
         rm src.txz
     )


### PR DESCRIPTION
stable/13 snapshots do not exist at the moment, and main (14.0-CURRENT)
AMIs aren't available yet either, so we must use release images/sources
for 13 for a little while.