### PR TITLE
FreeBSD: Update to 13.0-RC1

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -491,7 +491,7 @@ def get_freebsd12_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.0-BETA4")
+    slave.ami = freebsd_ami("amd64", "13.0-RC1")
     return slave.conn.get_image(slave.ami)
 
 #


### PR DESCRIPTION
The AMI and sources are now available.