### PR TITLE
Update FreeBSD 13 image to 13.0-RC4

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -491,7 +491,7 @@ def get_freebsd12_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.0-RC2")
+    slave.ami = freebsd_ami("amd64", "13.0-RC4")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd14_image(slave):


### PR DESCRIPTION
The RC2 files have aged out.