### PR TITLE
Use FreeBSD 13.0-RELEASE until snapshots come back

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -491,7 +491,7 @@ def get_freebsd12_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.0-RC5")
+    slave.ami = freebsd_ami("amd64", "13.0-RELEASE")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd14_image(slave):


### PR DESCRIPTION
The RC builds are gone, long live the release.