### PR TITLE
FreeBSD: Make Python support deps more robust

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -202,9 +202,11 @@ FreeBSD*)
         lcov
 
     # Python support libraries
-    pkg_install -y --no-repo-update \
-        py37-cffi \
-        py37-sysctl
+    pkg_install -xy --no-repo-update \
+        '^py3.+-cffi$' \
+        '^py3.+-sysctl$'
+
+    : # Succeed even if the last set of packages failed to install.
     ;;
 
 Ubuntu*)


### PR DESCRIPTION
Use regex package name to match py37 or py38, whichever is available.

Allow the python support deps to fail to install.