### PR TITLE
FreeBSD: FreeBSD 13-STABLE snapshots are available

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -491,7 +491,7 @@ def get_freebsd12_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.0-RELEASE")
+    slave.ami = freebsd_ami("amd64", "13.0-STABLE")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd14_image(slave):

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -163,10 +163,7 @@ FreeBSD*)
         ABI=$(uname -p)
         VERSION=$(freebsd-version -r)
         cd /tmp
-        # One of these will work, the other will fail.  We try both because 13 is
-        # in RC so there are not stable/13 snapshots at the moment.
         fetch https://download.freebsd.org/ftp/snapshots/${ABI}/${VERSION}/src.txz
-        fetch https://download.freebsd.org/ftp/releases/${ABI}/${VERSION}/src.txz
         sudo tar xpf src.txz -C /
         rm src.txz
     )


### PR DESCRIPTION
We can remove the release workaround now.