### PR TITLE
Missed a CentOS 8 package requirement.

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -98,7 +98,9 @@ CentOS*)
             python36-packaging
     elif cat /etc/centos-release | grep -Eq "release 8"; then
         sudo -E yum -y --skip-broken install libasan libtirpc-devel \
-            python3-devel python3-setuptools python3-cffi \
+            python3-devel python3-setuptools python3-cffi
+        # EL8 moved some dev tools into an entirely new repo.
+        sudo -E yum -y --skip-broken install --enablerepo=powertools \
             python3-packaging
     fi
 


### PR DESCRIPTION
I didn't test that EPEL didn't drop the -packaging package between
7 and 8, and deliberately didn't try to install both packaging and
distlib, which means I broke the CentOS 8 bots when openzfs/zfs#12073 goes in. Drat.

Install it from its new home instead.

(This one _has_ been tested on CentOS 8.)