### PR TITLE
Use Almalinux 8 AMI in place of CentOS 8

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -461,7 +461,21 @@ perf_factory.addStep(DirectoryUpload(
 # Provided by CentOS: https://wiki.centos.org/Cloud/AWS
 centos6_ami = "ami-ade6e5cd"		# CentOS 6 1-12-2018
 centos7_ami = "ami-08d2d8b00f270d03b"	# CentOS 7 1-06-2021
-centos8_ami = "ami-04179d30492b778ad"	# CentOS 8 6-18-2020
+
+# Centos 8 (NOTE!!!)
+#
+# After RedHat reported that CentOS would prematurely be EOL'd on
+# Dec 31 2021, we have decided to switch to Almalinux for CentOS 8
+# builders.  Almalinux is a open source, supported, clone on RHEL/CentOS 8.
+# We still use the "CentOS" naming in buildbot since it's still CentOS
+# compatible, and so we don't have to update all our bash scripts.
+#
+# This is the Almalinux 8 AMI:
+centos8_ami = "ami-0959211852ea0efa6"
+#
+# ... and for future reference, Almalinux 8 on us-west-2 is:
+# ami-0473bc9e4bfe85b1b
+
 centosstream8_ami = "ami-0f377b303df4963ab" # CentOS Stream 8 1-06-2021
 
 # Provided by Debian: https://wiki.debian.org/Cloud/AmazonEC2Image


### PR DESCRIPTION
After RedHat reported that CentOS would prematurely be EOL'd on Dec 31 2021, we have decided to switch to Almalinux for CentOS 8 builders.  Almalinux is a open source, supported, clone on RHEL/CentOS 8. We still use the "CentOS" naming in buildbot since it's still CentOS compatible, and so we don't have to update all our bash scripts.

I tested this on our internal buildbot packages builder, and was able to build packages and run the test suite using the new AMI.