### PR TITLE
Try to work around Debian kernel weirdness

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -118,8 +118,21 @@ Debian*)
         sysstat lsscsi parted gdebi attr dbench watchdog ksh nfs-kernel-server \
         samba rng-tools dkms rsync
 
+    # Workaround weirdness with the Debian 10 arm64 image
+    # It's trying to get an old bpo header package because it's running an old
+    # bpo kernel.
+    # Since it's no longer in the repos, let's put this in a separate command in case it fails,
+    # and just...go grab it, for now.
+    sudo -E apt-get --yes install linux-headers-$(uname -r)
+
+    if [ "$(uname -r)" = "5.10.0-0.bpo.8-cloud-arm64" ]; then
+	wget "https://snapshot.debian.org/archive/debian/20210901T090918Z/pool/main/l/linux/linux-headers-5.10.0-0.bpo.8-common_5.10.46-4~bpo10%2B1_all.deb"
+	wget "https://snapshot.debian.org/archive/debian/20210901T090918Z/pool/main/l/linux/linux-headers-5.10.0-0.bpo.8-arm64_5.10.46-4~bpo10%2B1_arm64.deb"
+	apt install `pwd`/linux-headers-*.deb
+    fi
+
     # Required development libraries
-    sudo -E apt-get --yes install linux-headers-$(uname -r) \
+    sudo -E apt-get --yes install \
         zlib1g-dev uuid-dev libblkid-dev libselinux-dev \
         xfslibs-dev libattr1-dev libacl1-dev libudev-dev libdevmapper-dev \
         libssl-dev libaio-dev libffi-dev libelf-dev libmount-dev \


### PR DESCRIPTION
Looking at [this](http://build.zfsonlinux.org/builders/Debian%2010%20arm64%20%28BUILD%29/builds/5110/steps/shell/logs/stdio), it fails to build later because zlib1g-dev didn't get installed when the huge apt install failed because of this:
```
+ sudo -E apt-get --yes install linux-headers-5.10.0-0.bpo.8-cloud-arm64 zlib1g-dev uuid-dev libblkid-dev libselinux-dev xfslibs-dev libattr1-dev libacl1-dev libudev-dev libdevmapper-dev libssl-dev libaio-dev libffi-dev libelf-dev libmount-dev libpam0g-dev pamtester python-dev python-setuptools python-cffi python-packaging python3 python3-dev python3-setuptools python3-cffi libcurl4-openssl-dev python3-packaging python-distlib python3-distlib
Reading package lists...
Building dependency tree...
Reading state information...
Package linux-headers-5.10.0-0.bpo.8-cloud-arm64 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'linux-headers-5.10.0-0.bpo.8-cloud-arm64' has no installation candidate
```

Which is curious, because the buildslave AMI itself is running 4.19.0-11-arm64, and the x86_64 testslave is getting a non-bpo kernel...

Unfortunately, I can't really see into the AMI instance that's spawned, so I can't tell what AMI it was running or why that has a BPO kernel and the x86_64 does not, just that in the ones that succeeded before it really is using those headers and not, say, the kernel version the buildbot has. Since the buildslave's AMIs are the only ones I see mentioned in the repo, I can't see where it would be getting one that is flawed like that...

So here's a workaround. Note that this should not be merged as-is - if this is going to happen, the relevant package files should be rehosted somewhere and that location pointed to instead, because otherwise the snapshot "mirror" is probably going to start banning hosts for hitting it too much.