### PR TITLE
Update FreeBSD 12 branch to 12.3-BETA3

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -502,7 +502,7 @@ def freebsd_ami(abi, version):
     return data['ImageId']
 
 def get_freebsd12_image(slave):
-    slave.ami = freebsd_ami("amd64", "12.3-PRERELEASE")
+    slave.ami = freebsd_ami("amd64", "12.3-BETA3")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -170,7 +170,8 @@ FreeBSD*)
         ABI=$(uname -p)
         VERSION=$(freebsd-version -r)
         cd /tmp
-        fetch https://download.freebsd.org/ftp/snapshots/${ABI}/${VERSION}/src.txz
+        fetch https://download.freebsd.org/ftp/snapshots/${ABI}/${VERSION}/src.txz ||
+        fetch https://download.freebsd.org/ftp/releases/${ABI}/${VERSION}/src.txz
         sudo tar xpf src.txz -C /
         rm src.txz
     )


### PR DESCRIPTION
During the release cycle we need to download sources from a different
location.  Add it as an alternative if the usual snapshot location
fails.