### PR TITLE
Switch back to FreeBSD 12.3-STABLE AMIs

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -502,7 +502,7 @@ def freebsd_ami(abi, version):
     return data['ImageId']
 
 def get_freebsd12_image(slave):
-    slave.ami = freebsd_ami("amd64", "12.3-RC1")
+    slave.ami = freebsd_ami("amd64", "12.3-STABLE")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):


### PR DESCRIPTION
The 12.3 release cycle is complete, and stable/12 snapshots are
available again.

Signed-off-by: Ryan Moeller <ryan@iXsystems.com>