### PR TITLE
Update to Fedora 35

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -484,7 +484,7 @@ debian10_amd64_ami = "ami-0ed1af421f2a3cf40" # Debian 10 9-9-2019
 debian10_arm64_ami = "ami-0a61b13f06119b46c" # Debian 10 9-28-2020
 
 # Provided by Fedora: https://alt.fedoraproject.org/cloud/
-fedora33_ami = "ami-03cd6589f3954c8ff"	# Fedora 33 10-28-2020
+fedora35_ami = "ami-052a62f38ec784c40"  # Fedora 35 Dec 13 2021
 
 # Provided by Cannonical: https://cloud-images.ubuntu.com/locator/ec2/
 ubuntu18_ami = "ami-03c9dad75296f9e90"	# Ubuntu 18.04 4-26-2018
@@ -593,10 +593,10 @@ debian10_x86_64_testslave = [
     ) for i in range(0, numtestslaves)
 ]
 
-fedora33_x86_64_testslave = [
+fedora35_x86_64_testslave = [
     ZFSEC2TestSlave(
-        name="Fedora-33-x86_64-testslave%s" % (str(i+1)),
-        ami=fedora33_ami
+        name="Fedora-35-x86_64-testslave%s" % (str(i+1)),
+        ami=fedora35_ami
     ) for i in range(0, numtestslaves)
 ]
 
@@ -641,7 +641,7 @@ test_slaves = \
     centos8_x86_64_testslave + \
     centosstream8_x86_64_testslave + \
     debian10_x86_64_testslave + \
-    fedora33_x86_64_testslave + \
+    fedora35_x86_64_testslave + \
     ubuntu18_x86_64_testslave + \
     ubuntu20_x86_64_testslave + \
     freebsd12_amd64_testslave + \
@@ -938,11 +938,11 @@ debian_10_builders = [
     ),
 ]
 
-fedora_33_builders = [
+fedora_35_builders = [
     ZFSBuilderConfig(
-        name="Fedora 33 x86_64 (TEST)",
+        name="Fedora 35 x86_64 (TEST)",
         factory=test_factory,
-        slavenames=[slave.name for slave in fedora33_x86_64_testslave],
+        slavenames=[slave.name for slave in fedora35_x86_64_testslave],
         tags=platform_tags,
         properties=builder_default_properties,
     ),
@@ -1004,7 +1004,7 @@ test_builders = \
     centos_8_builders + \
     centosstream_8_builders + \
     debian_10_builders + \
-    fedora_33_builders + \
+    fedora_35_builders + \
     ubuntu_18_builders + \
     ubuntu_20_builders + \
     freebsd_12_builders + \
@@ -1015,7 +1015,7 @@ nightly_builders = \
     centos_7_builders + \
     centos_8_builders + \
     debian_10_builders + \
-    fedora_33_builders + \
+    fedora_35_builders + \
     ubuntu_18_builders + \
     freebsd_12_builders + \
     freebsd_13_builders
@@ -1186,9 +1186,9 @@ c['schedulers'].append(CustomSingleBranchScheduler(
 
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-fedora-33-scheduler",
-    builderNames=[builder.name for builder in fedora_33_builders],
+    builderNames=[builder.name for builder in fedora_35_builders],
     codebases=default_codebases,
-    change_filter=filter.ChangeFilter(category_re=".*fedora33.*")))
+    change_filter=filter.ChangeFilter(category_re=".*fedora35.*")))
 
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-ubuntu-18-scheduler",

--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -312,8 +312,9 @@ Fedora*)
         # Python 2 has been removed from Fedora 32.  The required pip2
         # pacakages are still provided by the UnitedRPMs repository.
         if test $VERSION -ge 32; then
-            rpm --import https://raw.githubusercontent.com/UnitedRPMs/unitedrpms/master/URPMS-GPG-PUBLICKEY-Fedora
-            dnf -y install https://github.com/UnitedRPMs/unitedrpms/releases/download/17/unitedrpms-$(rpm -E %fedora)-17.fc$(rpm -E %fedora).noarch.rpm
+            yum -y install --skip-broken \
+                https://kojipkgs.fedoraproject.org/packages/python-pip/19.1.1/7.fc31/noarch/python2-pip-19.1.1-7.fc31.noarch.rpm \
+                https://kojipkgs.fedoraproject.org/packages/python-setuptools/41.6.0/1.fc31/noarch/python2-setuptools-41.6.0-1.fc31.noarch.rpm
         fi
 
         dnf -y install gcc python2 python2-devel python2-pip


### PR DESCRIPTION
- Search and replace Fedora 33 -> Fedora 35 and use new AMI
- Use official packages from kojipkgs.fedoraproject.org