### PR TITLE
FreeBSD: Tighten python dependencies regexes

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -209,9 +209,9 @@ FreeBSD*)
 
     # Python support libraries
     pkg_install -xy --no-repo-update \
-        '^py3.+-cffi$' \
-        '^py3.+-sysctl$' \
-        '^py3.+-packaging$'
+        '^py3[[:digit:]]+-cffi$' \
+        '^py3[[:digit:]]+-sysctl$' \
+        '^py3[[:digit:]]+-packaging$'
 
     : # Succeed even if the last set of packages failed to install.
     ;;


### PR DESCRIPTION
I noticed py38-jupyter-packaging being installed in test logs, which is
something we do not need.

Make the regex only match digits in the version an not anything in the
rest of the package name.