### PR TITLE
FreeBSD: Disable firstboot freebsd-update

### DIFF
--- a/master/buildslaves.py
+++ b/master/buildslaves.py
@@ -80,6 +80,8 @@ FreeBSD)
     # ttyv0,ttyu0,gdb -> ttyu0,ttyv0,gdb
     conscontrol delete ttyu0
     conscontrol add ttyu0
+    # While here, we also need to disable the automatic updates in release AMIs.
+    sysrc firstboot_freebsd_update_enable=NO
     ;;
 *)
     ;;


### PR DESCRIPTION
FreeBSD release AMIs perform a freebsd-update and reboot if necessary by
default on first boot.  We can't deal with the reboot cleanly, so opt
out of it.