### PR TITLE
Keep going while building built-in linux

### DIFF
--- a/scripts/bb-build-linux.sh
+++ b/scripts/bb-build-linux.sh
@@ -41,7 +41,7 @@ sh ./autogen.sh >>$MAKE_LOG 2>&1 || exit 1
 cd $LINUX_DIR
 # if we don't do this, make prints a warning
 sed -i '/CONFIG_ZFS/d;$aCONFIG_ZFS=y' .config
-make -j$(nproc) >>$MAKE_LOG 2>&1 || exit 1
-make -j$(nproc) modules >>$MAKE_LOG 2>&1 || exit 1
+make -kj$(nproc) >>$MAKE_LOG 2>&1 || exit 1
+make -kj$(nproc) modules >>$MAKE_LOG 2>&1 || exit 1
 
 exit 0

--- a/scripts/bb-build-linux.sh
+++ b/scripts/bb-build-linux.sh
@@ -40,11 +40,7 @@ sh ./autogen.sh >>$MAKE_LOG 2>&1 || exit 1
 # Build the kernel.
 cd $LINUX_DIR
 # if we don't do this, make prints a warning
-grep -v 'CONFIG_ZFS' .config > .tmpconfig
-mv .tmpconfig .config
-cat >> .config << EOF
-CONFIG_ZFS=y
-EOF
+sed -i '/CONFIG_ZFS/d;$aCONFIG_ZFS=y' .config
 make -j$(nproc) >>$MAKE_LOG 2>&1 || exit 1
 make -j$(nproc) modules >>$MAKE_LOG 2>&1 || exit 1
 


### PR DESCRIPTION
Continue building the kernel after the first errored target: this is what most people expect when building linux /and/ it helps to reveal all built-in errors at once, which is especially important considering that some parts Just Break, by design, on each Linus commit, which you don't necessarily care about