### PR TITLE
bb-build: export MAKE

### DIFF
--- a/scripts/bb-build-linux.sh
+++ b/scripts/bb-build-linux.sh
@@ -32,7 +32,7 @@ make prepare >>$MAKE_LOG 2>&1 || exit 1
 
 # Configure ZFS and add it to the kernel tree.
 cd $ZFS_DIR
-sh ./autogen.sh >>$MAKE_LOG 2>&1 || exit 1
+./autogen.sh >>$MAKE_LOG 2>&1 || exit 1
 ./configure --enable-linux-builtin --with-linux=$LINUX_DIR \
     --with-linux-obj=$LINUX_DIR >>$MAKE_LOG 2>&1 || exit 1
 ./copy-builtin $LINUX_DIR >>$MAKE_LOG 2>&1 || exit 1

--- a/scripts/bb-build.sh
+++ b/scripts/bb-build.sh
@@ -7,7 +7,7 @@ fi
 case "$BB_NAME" in
 FreeBSD*)
 	MAKE="gmake WITH_DEBUG=true"
-	if sysctl -n kern.conftxt | fgrep -qx $'options\tINVARIANTS'; then
+	if sysctl -n kern.conftxt | grep -Fqx $'options\tINVARIANTS'; then
 		MAKE="$MAKE WITH_INVARIANTS=true"
 	fi
 	NCPU=$(sysctl -n hw.ncpu)
@@ -44,7 +44,7 @@ fi
 
 set -x
 
-sh ./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
+./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
 
 case "$INSTALL_METHOD" in
 packages|kmod|pkg-kmod|dkms|dkms-kmod)

--- a/scripts/bb-build.sh
+++ b/scripts/bb-build.sh
@@ -22,6 +22,7 @@ Amazon*|CentOS*|Debian*|Fedora*|SUSE*|Ubuntu*)
 	NCPU=$(nproc)
 	;;
 esac
+export MAKE
 
 LINUX_OPTIONS=${LINUX_OPTIONS:-""}
 CONFIG_OPTIONS=${CONFIG_OPTIONS:-""}

--- a/scripts/openzfs-merge.sh
+++ b/scripts/openzfs-merge.sh
@@ -8,7 +8,7 @@
 # requirements.
 #
 # Repository setup for valid compilation check:
-#	sh autogen.sh
+#	./autogen.sh
 #	./configure --enable-debug
 #
 # mandatory git settings:


### PR DESCRIPTION
We already require gmake, but since https://github.com/openzfs/zfs/pull/13316 it's also required for proper bootstrapping, for which autohell defaults to just `make`; tested on FreeBSD 13-STABLE