### PR TITLE
Bump FreeBSD 13.1 to RC5

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -506,7 +506,7 @@ def get_freebsd12_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.1-RC3")
+    slave.ami = freebsd_ami("amd64", "13.1-RC5")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd14_image(slave):


### PR DESCRIPTION
FreeBSD 13.1-RC5 was released, bump the version used by the buildbot.