### PR TITLE
Bump FreeBSD 13.1 to RELEASE

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -506,7 +506,7 @@ def get_freebsd12_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.1-RC6")
+    slave.ami = freebsd_ami("amd64", "13.1-RELEASE")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd14_image(slave):


### PR DESCRIPTION
FreeBSD 13.1-RELEASE is out. 13.1-STABLE snapshots have not yet resumed, so use -RELEASE for now.