### PR TITLE
Start NFS and SMB on EL 9

### DIFF
--- a/scripts/bb-test-prepare.sh
+++ b/scripts/bb-test-prepare.sh
@@ -127,9 +127,7 @@ if echo "$TEST_PREPARE_WATCHDOG" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
     CentOS*)
         if cat /etc/redhat-release | grep -Eq "release 6."; then
             sudo -E /etc/init.d/watchdog start
-        elif cat /etc/redhat-release | grep -Eq "release 7."; then
-            sudo -E systemctl start watchdog
-        elif cat /etc/redhat-release | grep -Eq "release 8"; then
+        elif cat /etc/redhat-release | grep -Eq "release [7|8|9]"; then
             sudo -E systemctl start watchdog
         fi
         ;;
@@ -172,10 +170,7 @@ if echo "$TEST_PREPARE_SHARES" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
             sudo -E /etc/init.d/rpcbind start
             sudo -E /etc/init.d/nfs start
             sudo -E /etc/init.d/smb start
-        elif cat /etc/redhat-release | grep -Eq "release 7."; then
-            sudo -E systemctl start nfs-server
-            sudo -E systemctl start smb
-        elif cat /etc/redhat-release | grep -Eq "release 8"; then
+        elif cat /etc/redhat-release | grep -Eq "release [7|8|9]"; then
             sudo -E systemctl start nfs-server
             sudo -E systemctl start smb
         fi


### PR DESCRIPTION
Fix a bug where NFS was not being started on AlmaLinux 9. This was causing `zfs_share_005_pos` to fail.

This is untested, but pretty straightforward.

Fixes: https://github.com/openzfs/zfs/issues/13672