### PR TITLE
FreeBSD: bootstrap: Handle an existing swap

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -514,9 +514,9 @@ EOF
     fi
     if [ -n "$nvme" ]; then
         gpart create -s gpt ${nvme}
-        gpart add -t freebsd-ufs ${nvme}
-        newfs ${nvme}p1
-        mount -o noatime /dev/${nvme}p1 /mnt
+        nvmepart=$(gpart add -t freebsd-ufs ${nvme} | awk '{ print $1 }')
+        newfs ${nvmepart}
+        mount -o noatime /dev/${nvmepart} /mnt
     fi
     ;;
 


### PR DESCRIPTION
Recently a script built into FreeBSD AMIs that sets up a swap on
ephemeral storage was updated to work for NVMe storage as well.  This
interferes with our attempt to partition and format the device for /mnt.

As a result, nothing gets mounted on /mnt, so the tests fill up the root
filesystem and evenually fail.

Remedy this by checking which partition was added rather than assuming
it was the first one.