### PR TITLE
Don't fail to install dependencies if kernel headers fail on Debian

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -124,8 +124,14 @@ Debian*)
         sysstat lsscsi parted gdebi attr dbench watchdog ksh nfs-kernel-server \
         samba rng-tools dkms rsync
 
+    # Running kernel headers (separate so it failing doesn't fail to install
+    # other dependencies)
+    sudo -E apt-get --yes install linux-headers-$(uname -r)
+    # Latest kernel headers (just in case) (ditto)
+    sudo -E apt-get --yes install linux-headers-$(dpkg-architecture -q DEB_TARGET_ARCH)
+    
     # Required development libraries
-    sudo -E apt-get --yes install linux-headers-$(uname -r) \
+    sudo -E apt-get --yes install \
         zlib1g-dev uuid-dev libblkid-dev libselinux-dev \
         xfslibs-dev libattr1-dev libacl1-dev libudev-dev libdevmapper-dev \
         libssl-dev libaio-dev libffi-dev libelf-dev libmount-dev \


### PR DESCRIPTION
As [the buildbot shows](http://build.zfsonlinux.org/builders/Debian%2010%20arm64%20%28BUILD%29) right now, if the big monolithic apt-get command has a package missing (say, linux-headers-4.19.0-11-arm64), it will fail to install any of them.

Since breaking it into a bunch of install commands would increase the runtime substantially, just break out the headers install to a separate command, have it fall back to trying to install the latest headers for the arch anyway, and then install the other dependencies separately, so hopefully the erroring next time requires less digging to figure out the kernel headers were missing, not zlib1g-dev.

(Technically it having any headers could make it succeed and fail to load modules later, but since I _suspect_ what's happening is the initial VM bringup is slightly too old so its headers are no longer in the repo, either we try with the latest headers assuming we're going to be using that kernel version, or we fail until someone updates the base VM.

If we want to be sure we boot the latest kernel, of course, we could explicitly install that...)