### PR TITLE
FreeBSD: Work around Python 2.7 EOL breakage

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -496,6 +496,7 @@ EOF
         python27 \
         sudo
     python2.7 -m ensurepip
+    pip --quiet install typing
     pip --quiet install buildbot-slave
 
     pw useradd buildbot


### PR DESCRIPTION
We need Python 2.7 for our ancient version of buildbot, which we install from pip.  However, Python 2.7 is EOL and pip barely works with it anymore.  The buildbot-slave package depends on twisted, which in turn depends on typing, which pip now fails to automatically install on FreeBSD.

Work around the breakage by explicitly installing the typing package.