### PR TITLE
Update FreeBSD versions

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -504,11 +504,11 @@ def freebsd_ami(abi, version):
     return data['ImageId']
 
 def get_freebsd12_image(slave):
-    slave.ami = freebsd_ami("amd64", "12.3-STABLE")
+    slave.ami = freebsd_ami("amd64", "12.4-STABLE")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd13_image(slave):
-    slave.ami = freebsd_ami("amd64", "13.1-STABLE")
+    slave.ami = freebsd_ami("amd64", "13.2-PRERELEASE")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd14_image(slave):


### PR DESCRIPTION
The latest FreeBSD stable branches are now at 12.4-STABLE and 13.2-PRERELEASE.