### PR TITLE
Add Fedora 37 builder, update EL9, add to README.md

### DIFF
--- a/master/github.py
+++ b/master/github.py
@@ -13,7 +13,7 @@ from dateutil.parser import parse as dateparse
 from twisted.python import log
 
 builders_common="arch,"
-builders_linux="centos7,centos8,centos9,centosstream8,debian10,fedora35,builtin,"
+builders_linux="centos7,centos8,centos9,centosstream8,debian10,fedora37,builtin,"
 builders_freebsd="freebsd13,freebsd14"
 
 builders_push_master=builders_common+builders_linux+builders_freebsd+"coverage"

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -473,7 +473,7 @@ centos7_ami = "ami-08d2d8b00f270d03b"	# CentOS 7 1-06-2021
 centos8_ami = "ami-0473bc9e4bfe85b1b"
 
 # Almalinux 9
-centos9_ami = "ami-039a84746460b9f2d"
+centos9_ami = "ami-0a72198ef1b8f6dfa"
 
 #
 # ... and for future reference, Almalinux 8 on us-west-2 is:
@@ -486,7 +486,7 @@ debian10_amd64_ami = "ami-0ed1af421f2a3cf40" # Debian 10 9-9-2019
 debian10_arm64_ami = "ami-0a61b13f06119b46c" # Debian 10 9-28-2020
 
 # Provided by Fedora: https://alt.fedoraproject.org/cloud/
-fedora35_ami = "ami-052a62f38ec784c40"  # Fedora 35 Dec 13 2021
+fedora37_ami = "ami-019b893191a9ac44a"
 
 # Provided by Cannonical: https://cloud-images.ubuntu.com/locator/ec2/
 ubuntu18_ami = "ami-03c9dad75296f9e90"	# Ubuntu 18.04 4-26-2018
@@ -587,10 +587,10 @@ debian10_x86_64_testslave = [
     ) for i in range(0, numtestslaves)
 ]
 
-fedora35_x86_64_testslave = [
+fedora37_x86_64_testslave = [
     ZFSEC2TestSlave(
-        name="Fedora-35-x86_64-testslave%s" % (str(i+1)),
-        ami=fedora35_ami
+        name="Fedora-37-x86_64-testslave%s" % (str(i+1)),
+        ami=fedora37_ami
     ) for i in range(0, numtestslaves)
 ]
 
@@ -621,7 +621,7 @@ test_slaves = \
     centos9_x86_64_testslave + \
     centosstream8_x86_64_testslave + \
     debian10_x86_64_testslave + \
-    fedora35_x86_64_testslave + \
+    fedora37_x86_64_testslave + \
     freebsd12_amd64_testslave + \
     freebsd13_amd64_testslave + \
     freebsd14_amd64_testslave
@@ -909,11 +909,11 @@ debian_10_builders = [
     ),
 ]
 
-fedora_35_builders = [
+fedora_37_builders = [
     ZFSBuilderConfig(
-        name="Fedora 35 x86_64 (TEST)",
+        name="Fedora 37 x86_64 (TEST)",
         factory=test_factory,
-        slavenames=[slave.name for slave in fedora35_x86_64_testslave],
+        slavenames=[slave.name for slave in fedora37_x86_64_testslave],
         tags=platform_tags,
         properties=builder_default_properties,
     ),
@@ -955,7 +955,7 @@ test_builders = \
     centos_9_builders + \
     centosstream_8_builders + \
     debian_10_builders + \
-    fedora_35_builders + \
+    fedora_37_builders + \
     freebsd_12_builders + \
     freebsd_13_builders + \
     freebsd_14_builders
@@ -965,7 +965,7 @@ nightly_builders = \
     centos_8_builders + \
     centos_9_builders + \
     debian_10_builders + \
-    fedora_35_builders + \
+    fedora_37_builders + \
     freebsd_13_builders + \
     freebsd_14_builders
 
@@ -1134,10 +1134,10 @@ c['schedulers'].append(CustomSingleBranchScheduler(
     change_filter=filter.ChangeFilter(category_re=".*debian10.*")))
 
 c['schedulers'].append(CustomSingleBranchScheduler(
-    name="pull-request-fedora-33-scheduler",
-    builderNames=[builder.name for builder in fedora_35_builders],
+    name="pull-request-fedora-37-scheduler",
+    builderNames=[builder.name for builder in fedora_37_builders],
     codebases=default_codebases,
-    change_filter=filter.ChangeFilter(category_re=".*fedora35.*")))
+    change_filter=filter.ChangeFilter(category_re=".*fedora37.*")))
 
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-freebsd-12-scheduler",


### PR DESCRIPTION
- Update AMI for AlmaLinux 9
- Replace Fedora 35 (deprecated) builder with Fedora 37
- Update README.md with step-by-step instructions for setting up a buildbot server on Ubuntu 18.04.