### PR TITLE
More Fedora 37, EL9 fixes

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -486,7 +486,7 @@ debian10_amd64_ami = "ami-0ed1af421f2a3cf40" # Debian 10 9-9-2019
 debian10_arm64_ami = "ami-0a61b13f06119b46c" # Debian 10 9-28-2020
 
 # Provided by Fedora: https://alt.fedoraproject.org/cloud/
-fedora37_ami = "ami-019b893191a9ac44a"
+fedora37_ami = "ami-04e37334d4e907fab"
 
 # Provided by Cannonical: https://cloud-images.ubuntu.com/locator/ec2/
 ubuntu18_ami = "ami-03c9dad75296f9e90"	# Ubuntu 18.04 4-26-2018

--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -335,6 +335,7 @@ CentOS*)
         $PIP install buildbot-slave
     elif cat /etc/redhat-release | grep -Eq "release 9."; then
         install_python2_from_source
+        pip2.7 install Automat==0.8.0
         pip2.7 install pathlib
         pip2.7 install twisted
         pip2.7 install buildbot-slave==0.8.14


### PR DESCRIPTION
- Use F37 us-west-1 AMI instead of us-west-2
- Use Automat version 0.8.0 like we do with CentOS 8.  This gets around a python error in bb-bootstrap.sh