### PR TITLE
Add Fedora 38 builder

### DIFF
--- a/master/github.py
+++ b/master/github.py
@@ -13,7 +13,7 @@ from dateutil.parser import parse as dateparse
 from twisted.python import log
 
 builders_common="arch,"
-builders_linux="centos7,centos8,centos9,centosstream8,fedora37,builtin,"
+builders_linux="centos7,centos8,centos9,centosstream8,fedora37,fedora38,builtin,"
 builders_freebsd="freebsd13"
 
 builders_push_master=builders_common+builders_linux+builders_freebsd+"coverage"

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -486,6 +486,7 @@ debian10_amd64_ami = "ami-0ed1af421f2a3cf40" # Debian 10 9-9-2019
 
 # Provided by Fedora: https://alt.fedoraproject.org/cloud/
 fedora37_ami = "ami-04e37334d4e907fab"
+fedora38_ami = "ami-079ff5fcdb66fcf9b"
 
 # Provided by Cannonical: https://cloud-images.ubuntu.com/locator/ec2/
 ubuntu18_ami = "ami-03c9dad75296f9e90"	# Ubuntu 18.04 4-26-2018
@@ -576,6 +577,13 @@ fedora37_x86_64_testslave = [
     ) for i in range(0, numtestslaves)
 ]
 
+fedora38_x86_64_testslave = [
+    ZFSEC2TestSlave(
+        name="Fedora-38-x86_64-testslave%s" % (str(i+1)),
+        ami=fedora38_ami
+    ) for i in range(0, numtestslaves)
+]
+
 freebsd12_amd64_testslave = [
     ZFSEC2TestSlave(
         name="FreeBSD-stable/12-amd64-testslave%s" % (str(i+1)),
@@ -604,6 +612,7 @@ test_slaves = \
     centosstream8_x86_64_testslave + \
     debian10_x86_64_testslave + \
     fedora37_x86_64_testslave + \
+    fedora38_x86_64_testslave + \
     freebsd12_amd64_testslave + \
     freebsd13_amd64_testslave + \
     freebsd14_amd64_testslave
@@ -887,6 +896,16 @@ fedora_37_builders = [
     ),
 ]
 
+fedora_38_builders = [
+    ZFSBuilderConfig(
+        name="Fedora 38 x86_64 (TEST)",
+        factory=test_factory,
+        slavenames=[slave.name for slave in fedora38_x86_64_testslave],
+        tags=platform_tags,
+        properties=builder_default_properties,
+    ),
+]
+
 freebsd_12_builders = [
     ZFSBuilderConfig(
         name="FreeBSD stable/12 amd64 (TEST)",
@@ -924,6 +943,7 @@ test_builders = \
     centosstream_8_builders + \
     debian_10_builders + \
     fedora_37_builders + \
+    fedora_38_builders + \
     freebsd_12_builders + \
     freebsd_13_builders + \
     freebsd_14_builders
@@ -933,6 +953,7 @@ nightly_builders = \
     centos_8_builders + \
     centos_9_builders + \
     fedora_37_builders + \
+    fedora_38_builders + \
     freebsd_13_builders
 
 #
@@ -1104,6 +1125,12 @@ c['schedulers'].append(CustomSingleBranchScheduler(
     builderNames=[builder.name for builder in fedora_37_builders],
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*fedora37.*")))
+
+c['schedulers'].append(CustomSingleBranchScheduler(
+    name="pull-request-fedora-38-scheduler",
+    builderNames=[builder.name for builder in fedora_38_builders],
+    codebases=default_codebases,
+    change_filter=filter.ChangeFilter(category_re=".*fedora38.*")))
 
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-freebsd-12-scheduler",


### PR DESCRIPTION
I tested this on our buildbot development server and saw it launch a F38 builder.  The F38 builder successfully built ZFS, and is currently running though ZTS.