### PR TITLE
Update to FreeBSD 14.0-RC2 ami

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -533,7 +533,7 @@ def get_freebsd13_image(slave):
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd14_image(slave):
-    slave.ami = freebsd_ami("x86_64", "14-RC1")
+    slave.ami = freebsd_ami("x86_64", "14-RC2")
     return slave.conn.get_image(slave.ami)
 
 def get_freebsd15_image(slave):


### PR DESCRIPTION
Bump image to FreeBSD 14.0-RC2.  This may resolve the CI issue we're seeing where the FreeBSD-14.0-RC1 ami [doesn't properly start up](https://build.openzfs.org/builders/FreeBSD%20stable%2F14%20amd64%20%28TEST%29) and connect to the CI.