### PR TITLE
FreeBSD replace samba413 with samba416

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -239,7 +239,7 @@ FreeBSD*)
     # Testing support utilities
     # Only a few tests require these.
     pkg_install -y --no-repo-update \
-        samba413 \
+        samba416 \
         gdb \
         pamtester \
         lcov \


### PR DESCRIPTION
This package has been deprecated and is no longer available. Update to samba416.